### PR TITLE
Clarify required prefix in numeric replies

### DIFF
--- a/index.md
+++ b/index.md
@@ -486,9 +486,9 @@ Please also see our [Message Parsing and Assembly](#message-parsing-and-assembly
 
 ## Numeric Replies
 
-Most messages sent from a client to a server generates a reply of some sort. The most common form of reply is the numeric reply, used for both errors and normal replies. Distinct from a normal message, a numeric reply MUST contain the sender prefix and the three-digit numeric. A numeric reply SHOULD contain the target of the reply as the first parameter of the message. A numeric reply is not allowed to originate from a client.
+Most messages sent from a client to a server generates a reply of some sort. The most common form of reply is the numeric reply, used for both errors and normal replies. Distinct from a normal message, a numeric reply MUST contain the sender prefix and use a three-digit numeric as the command. A numeric reply SHOULD contain the target of the reply as the first parameter of the message. A numeric reply is not allowed to originate from a client.
 
-In all other respects, a numeric reply is just like a normal message, except that the command is made up of 3 numeric digits rather than a string of letters. A list of numeric replies is supplied in the [Numerics](#numerics) section.
+In all other respects, a numeric reply is just like a normal message. A list of numeric replies is supplied in the [Numerics](#numerics) section.
 
 
 ## Wildcard Expressions

--- a/index.md
+++ b/index.md
@@ -486,7 +486,7 @@ Please also see our [Message Parsing and Assembly](#message-parsing-and-assembly
 
 ## Numeric Replies
 
-Most messages sent from a client to a server generates a reply of some sort. The most common form of reply is the numeric reply, used for both errors and normal replies. A numeric reply MUST be sent as one message containing the sender prefix and the three-digit numeric. A numeric reply SHOULD contain the target of the reply as the first parameter of the message. A numeric reply is not allowed to originate from a client.
+Most messages sent from a client to a server generates a reply of some sort. The most common form of reply is the numeric reply, used for both errors and normal replies. Distinct from a normal message, a numeric reply is MUST contain the sender prefix and the three-digit numeric. A numeric reply SHOULD contain the target of the reply as the first parameter of the message. A numeric reply is not allowed to originate from a client.
 
 In all other respects, a numeric reply is just like a normal message, except that the keyword is made up of 3 numeric digits rather than a string of letters. A list of numeric replies is supplied in the [Numerics](#numerics) section.
 

--- a/index.md
+++ b/index.md
@@ -488,7 +488,7 @@ Please also see our [Message Parsing and Assembly](#message-parsing-and-assembly
 
 Most messages sent from a client to a server generates a reply of some sort. The most common form of reply is the numeric reply, used for both errors and normal replies. Distinct from a normal message, a numeric reply MUST contain the sender prefix and the three-digit numeric. A numeric reply SHOULD contain the target of the reply as the first parameter of the message. A numeric reply is not allowed to originate from a client.
 
-In all other respects, a numeric reply is just like a normal message, except that the keyword is made up of 3 numeric digits rather than a string of letters. A list of numeric replies is supplied in the [Numerics](#numerics) section.
+In all other respects, a numeric reply is just like a normal message, except that the command is made up of 3 numeric digits rather than a string of letters. A list of numeric replies is supplied in the [Numerics](#numerics) section.
 
 
 ## Wildcard Expressions

--- a/index.md
+++ b/index.md
@@ -486,7 +486,7 @@ Please also see our [Message Parsing and Assembly](#message-parsing-and-assembly
 
 ## Numeric Replies
 
-Most messages sent from a client to a server generates a reply of some sort. The most common form of reply is the numeric reply, used for both errors and normal replies. Distinct from a normal message, a numeric reply is MUST contain the sender prefix and the three-digit numeric. A numeric reply SHOULD contain the target of the reply as the first parameter of the message. A numeric reply is not allowed to originate from a client.
+Most messages sent from a client to a server generates a reply of some sort. The most common form of reply is the numeric reply, used for both errors and normal replies. Distinct from a normal message, a numeric reply MUST contain the sender prefix and the three-digit numeric. A numeric reply SHOULD contain the target of the reply as the first parameter of the message. A numeric reply is not allowed to originate from a client.
 
 In all other respects, a numeric reply is just like a normal message, except that the keyword is made up of 3 numeric digits rather than a string of letters. A list of numeric replies is supplied in the [Numerics](#numerics) section.
 


### PR DESCRIPTION
As raised here: https://github.com/znc/znc/issues/1640

modern, and both RFCs state that for "messages" ([rfc1459][1] / [rfc2812][2]) the prefix is optional, but for "numeric replies" ([rfc1459][3] / [rfc2812][4]) it MUST be sent, but it's a bit confusing and it's not clear that they're distinct.

Maybe this change in wording would help?

[1]: https://tools.ietf.org/html/rfc1459#section-2.3
[2]: https://tools.ietf.org/html/rfc1459#section-2.4
[3]: https://tools.ietf.org/html/rfc2812#section-2.3
[4]: https://tools.ietf.org/html/rfc2812#section-2.4