### PR TITLE
Fix RPL_INVITING parameter order

### DIFF
--- a/_includes/modern-appendix.md
+++ b/_includes/modern-appendix.md
@@ -506,7 +506,7 @@ Sent to a client to let them know who set the topic (`<nick>`) and when they set
 
 ### `RPL_INVITING (341)`
 
-      "<client> <channel> <nick>"
+      "<client> <nick> <channel>"
 
 Sent as a reply to the [`INVITE`](#invite-message) command to indicate that the attempt was successful and the client with the nickname `<nick>` has been invited to `<channel>`.
 


### PR DESCRIPTION
The former order was what is in the RFC, but there is an erratum that
have switched the last two params.  Thus pointing to this erratum to
explain properly why modern-ircdocs would differ from the RFC.