### PR TITLE
ERR_PASSWDMISMATCH may be used in reply to PASS

### DIFF
--- a/index.md
+++ b/index.md
@@ -648,6 +648,7 @@ Numeric replies:
 
 * [`ERR_NEEDMOREPARAMS`](#errneedmoreparams-461) `(461)`
 * [`ERR_ALREADYREGISTRED`](#erralreadyregistered-462) `(462)`
+* [`ERR_PASSWDMISMATCH`](#errpasswdmismatch-464) `(464)`
 
 Command Example:
 


### PR DESCRIPTION
In case the password provided in the PASS command is incorrect, the
server may reply with ERR_PASSWDMISMATCH.