### PR TITLE
ERR_NOSUCHNICK is not a numeric reply for NAMES

### DIFF
--- a/index.md
+++ b/index.md
@@ -918,7 +918,6 @@ If no parameter is given for this command, servers SHOULD return one `RPL_ENDOFN
 
 Numeric Replies:
 
-* [`ERR_NOSUCHNICK`](#errnosuchnick-401) `(401)`
 * [`RPL_NAMREPLY`](#rplnamreply-353) `(353)`
 * [`RPL_ENDOFNAMES`](#rplendofnames-366) `(366)`
 


### PR DESCRIPTION
`NAMES invalid` returns a single RPL_ENDOFNAMES message, not an
ERR_NOSUCHNICK message.