### PR TITLE
Invisible User Mode: Fix description of interaction with WHOIS

### DIFF
--- a/_includes/modern-appendix.md
+++ b/_includes/modern-appendix.md
@@ -46,7 +46,7 @@ We only cover modes that are widely-used by IRC software today and whose meaning
 
 This mode is standard, and the mode letter used for it is `"+i"`.
 
-If a user is set to 'invisible', they will not show up in commands such as [`WHO`](#who-command) unless they share a channel with the user that submitted the command. In addition, the only channels that will show up in a [`WHOIS`](#whois-command) of an invisible user will be those they share with the user that submitted the command.
+If a user is set to 'invisible', they will not show up in commands such as [`WHO`](#who-command) or [`NAMES`](#names-command) unless they share a channel with the user that submitted the command. In addition, some servers hide all channels from the [`WHOIS`](#whois-command) reply of an invisible user they do not share with the user that submitted the command.
 
 ### Oper User Mode
 


### PR DESCRIPTION
Closes GH-64, which pointed out that it's a behavior specific to ircd-seven
(and probably Solanum too now).

Ref : tested on Unreal and confirmed by its documentation:
https://www.unrealircd.org/docs/User_modes