### PR TITLE
On topic change, only the TOPIC command is sent/echoed, never RPL_TOPIC/RPL_NOTOPIC.

### DIFF
--- a/_includes/modern-appendix.md
+++ b/_includes/modern-appendix.md
@@ -490,13 +490,13 @@ Sent to a client to inform them of the creation time of a channel. `<channel>` i
 
       "<client> <channel> :No topic is set"
 
-Sent as a reply to the [`TOPIC`](#topic-message) command, this numeric indicates that the channel with the name `<channel>` does not have any topic set.
+Sent to a client when joining a channel to inform them that the channel with the name `<channel>` does not have any topic set.
 
 ### `RPL_TOPIC (332)`
 
       "<client> <channel> :<topic>"
 
-Sent to a client to inform them of the current [topic](#topic-message) of the channel.
+Sent to a client when joining the `<channel>` to inform them of the current [topic](#topic-message) of the channel.
 
 ### `RPL_TOPICWHOTIME (333)`
 

--- a/index.md
+++ b/index.md
@@ -883,7 +883,9 @@ If `RPL_TOPIC` is returned to the client sending this command, `RPL_TOPICWHOTIME
 
 If the [protected topic](#protected-topic-mode) mode is set on a channel, then clients MUST have appropriate channel permissions to modify the topic of that channel. If a client does not have appropriate channel permissions and tries to change the topic, the [`ERR_CHANOPRIVSNEEDED`](#errchanoprivsneeded-482) numeric is returned and the command will fail.
 
-If the topic of a channel is changed or cleared, every client in that channel will receive either a `RPL_TOPIC` or `RPL_NOTOPIC` numeric alerting them to how the topic has changed.
+If the topic of a channel is changed or cleared, every client in that channel (including the author of the topic change) will receive a `TOPIC` command with the new topic as argument (or an empty argument if the topic was cleared) alerting them to how the topic has changed.
+
+Clients joining the channel in the future with receive either a `RPL_TOPIC` or `RPL_NOTOPIC` numeric accordingly.
 
 Numeric Replies:
 

--- a/index.md
+++ b/index.md
@@ -885,7 +885,7 @@ If the [protected topic](#protected-topic-mode) mode is set on a channel, then c
 
 If the topic of a channel is changed or cleared, every client in that channel (including the author of the topic change) will receive a `TOPIC` command with the new topic as argument (or an empty argument if the topic was cleared) alerting them to how the topic has changed.
 
-Clients joining the channel in the future with receive either a `RPL_TOPIC` or `RPL_NOTOPIC` numeric accordingly.
+Clients joining the channel in the future with receive a `RPL_TOPIC` numeric (or lack thereof) accordingly.
 
 Numeric Replies:
 

--- a/index.md
+++ b/index.md
@@ -885,7 +885,7 @@ If the [protected topic](#protected-topic-mode) mode is set on a channel, then c
 
 If the topic of a channel is changed or cleared, every client in that channel (including the author of the topic change) will receive a `TOPIC` command with the new topic as argument (or an empty argument if the topic was cleared) alerting them to how the topic has changed.
 
-Clients joining the channel in the future with receive a `RPL_TOPIC` numeric (or lack thereof) accordingly.
+Clients joining the channel in the future will receive a `RPL_TOPIC` numeric (or lack thereof) accordingly.
 
 Numeric Replies:
 


### PR DESCRIPTION
Checked on:

* inspircd
* unreal
* chary
* hybrid
* solanum
* ergo

using irctest (https://github.com/ProgVal/irctest/commit/4fb7ebcd2cb07232b87900a271961659604a2cf1 and https://github.com/ProgVal/irctest/commit/59c7252da1d5c4ef40dcf5ce5f3ef2dfbaf9eb52)

Closes GH-66