### PR TITLE
Specify the HELP command.

### DIFF
--- a/_data/modern.yml
+++ b/_data/modern.yml
@@ -668,6 +668,9 @@ numerics:
   ERR_WHOLIMEXCEED:
     numeric: '523'
 
+  ERR_HELPNOTFOUND:
+    numeric: '524'
+
   ERR_INVALIDKEY:
     numeric: '525'
 

--- a/_includes/modern-appendix.md
+++ b/_includes/modern-appendix.md
@@ -866,7 +866,7 @@ The `<subject>` MUST be the one requested by the client, but may be casefolded; 
 
 Returns a line of {% command HELP %} text to the client. Lines MAY be wrapped to a certain line length by the server. Note that the final line MUST be a {% numeric RPL_ENDOFHELP %} numeric.
 
-The `<subject>` MUST be the one requested by the client, up to casing; unless it would be an invalid parameter, in which case it MUST be `*`.
+The `<subject>` MUST be the one requested by the client, but may be casefolded; unless it would be an invalid parameter, in which case it MUST be `*`.
 
 {% numericheader RPL_ENDOFHELP %}
 
@@ -874,7 +874,7 @@ The `<subject>` MUST be the one requested by the client, up to casing; unless it
 
 Returns the final {% command HELP %} line to the client.
 
-The `<subject>` MUST be the one requested by the client, up to casing; unless it would be an invalid parameter, in which case it MUST be `*`.
+The `<subject>` MUST be the one requested by the client, but may be casefolded; unless it would be an invalid parameter, in which case it MUST be `*`.
 
 {% numericheader ERR_NOPRIVS %}
 

--- a/_includes/modern-appendix.md
+++ b/_includes/modern-appendix.md
@@ -856,7 +856,7 @@ Indicates that there was a problem with a mode parameter. Replaces various imple
     "<client> <subject> :<first line of help section>"
 
 Indicates the start of a reply to a {% command HELP %} command.
-The text used in the last param of this message may vary, and SHOULD be displayed as-is by IRC clients to their users; possibly emphasized as a the title of the help section.
+The text used in the last parameter of this message may vary, and SHOULD be displayed as-is by IRC clients to their users; possibly emphasized as the title of the help section.
 
 The `<subject>` MUST be the one requested by the client, but may be casefolded; unless it would be an invalid parameter, in which case it MUST be `*`.
 

--- a/_includes/modern-appendix.md
+++ b/_includes/modern-appendix.md
@@ -864,7 +864,7 @@ The `<subject>` MUST be the one requested by the client, but may be casefolded; 
 
     "<client> <subject> :<line of help text>"
 
-When sending a reply to a {% command HELP %} command to the client, servers reply with each line of the help section as this numeric. Help lines MAY be wrapped to 80 characters by the server.
+Returns a line of {% command HELP %} text to the client. Lines MAY be wrapped to a certain line length by the server. Note that the final line MUST be a {% numeric RPL_ENDOFHELP %} numeric.
 
 The `<subject>` MUST be the one requested by the client, up to casing; unless it would be an invalid parameter, in which case it MUST be `*`.
 

--- a/_includes/modern-appendix.md
+++ b/_includes/modern-appendix.md
@@ -872,8 +872,7 @@ The `<subject>` MUST be the one requested by the client, up to casing; unless it
 
     "<client> <subject> :<last line of help text>"
 
-Indicates the end of the reply to the {% command HELP %} command to the client.
-The text used in the last param of this message may vary, and SHOULD be shown to the user as any other line.
+Returns the final {% command HELP %} line to the client.
 
 The `<subject>` MUST be the one requested by the client, up to casing; unless it would be an invalid parameter, in which case it MUST be `*`.
 

--- a/_includes/modern-appendix.md
+++ b/_includes/modern-appendix.md
@@ -813,6 +813,14 @@ Indicates that a {% message MODE %} command affecting a user contained a `MODE` 
 
 Indicates that a {% message MODE %} command affecting a user failed because they were trying to set or view modes for other users. The text used in the last param of this message varies, for instance when trying to view modes for another user, a server may send: `"Can't view modes for other users"`.
 
+{% numericheader ERR_HELPNOTFOUND %}
+
+      "<client> <subject> :No help available on this topic"
+
+Indicates that a {% message HELP %} command requested help on a subject the server does not know about.
+
+The `<subject>` MUST be the one requested by the client, up to casing; unless it would be an invalid parameter, in which case it MUST be `*`.
+
 {% numericheader ERR_INVALIDKEY %}
 
     "<client> <target chan> :Key is not well-formed"
@@ -842,6 +850,32 @@ The text used in the last param of this message varies wildly.
     "<client> <target chan/user> <mode char> <parameter> :<description>"
 
 Indicates that there was a problem with a mode parameter. Replaces various implementation-specific mode-specific numerics.
+
+{% numericheader RPL_HELPSTART %}
+
+    "<client> <subject> :<firt line of help section>"
+
+Indicates the start of a reply to a {% command HELP %} command to the client.
+The text used in the last param of this message may vary, and SHOULD be displayed as-is by IRC clients to their users; possibly emphasized as a the title of the help section.
+
+The `<subject>` MUST be the one requested by the client, up to casing; unless it would be an invalid parameter, in which case it MUST be `*`.
+
+{% numericheader RPL_HELPTXT %}
+
+    "<client> <subject> :<line of help text>"
+
+When sending a reply to a {% command HELP %} command to the client, servers reply with each line of the help section as this numeric. Help lines MAY be wrapped to 80 characters by the server.
+
+The `<subject>` MUST be the one requested by the client, up to casing; unless it would be an invalid parameter, in which case it MUST be `*`.
+
+{% numericheader RPL_ENDOFHELP %}
+
+    "<client> <subject> :<last line of help text>"
+
+Indicates the end of the reply to the {% command HELP %} command to the client.
+The text used in the last param of this message may vary, and SHOULD be shown to the user as any other line.
+
+The `<subject>` MUST be the one requested by the client, up to casing; unless it would be an invalid parameter, in which case it MUST be `*`.
 
 {% numericheader ERR_NOPRIVS %}
 

--- a/_includes/modern-appendix.md
+++ b/_includes/modern-appendix.md
@@ -819,7 +819,7 @@ Indicates that a {% message MODE %} command affecting a user failed because they
 
 Indicates that a {% message HELP %} command requested help on a subject the server does not know about.
 
-The `<subject>` MUST be the one requested by the client, up to casing; unless it would be an invalid parameter, in which case it MUST be `*`.
+The `<subject>` MUST be the one requested by the client, but may be casefolded; unless it would be an invalid parameter, in which case it MUST be `*`.
 
 {% numericheader ERR_INVALIDKEY %}
 

--- a/_includes/modern-appendix.md
+++ b/_includes/modern-appendix.md
@@ -853,12 +853,12 @@ Indicates that there was a problem with a mode parameter. Replaces various imple
 
 {% numericheader RPL_HELPSTART %}
 
-    "<client> <subject> :<firt line of help section>"
+    "<client> <subject> :<first line of help section>"
 
-Indicates the start of a reply to a {% command HELP %} command to the client.
+Indicates the start of a reply to a {% command HELP %} command.
 The text used in the last param of this message may vary, and SHOULD be displayed as-is by IRC clients to their users; possibly emphasized as a the title of the help section.
 
-The `<subject>` MUST be the one requested by the client, up to casing; unless it would be an invalid parameter, in which case it MUST be `*`.
+The `<subject>` MUST be the one requested by the client, but may be casefolded; unless it would be an invalid parameter, in which case it MUST be `*`.
 
 {% numericheader RPL_HELPTXT %}
 

--- a/index.md
+++ b/index.md
@@ -1228,6 +1228,62 @@ Command Examples:
       :Wiz STATS c eff.org            ; request by WiZ for C/N line
                                       information from server eff.org
 
+### HELP message
+
+         Command: HELP
+      Parameters: [<subject>]
+
+The `HELP` command is used to return documentation about the IRC server and the IRC commands it implements.
+When receiving an `HELP` command, servers MUST either:
+
+1. reply with {% numeric ERR_UNKNOWNCOMMAND %} if they don't support the command at all,
+2. reply with a single {% numeric ERR_HELPNOTFOUND %} message if they do not know about the `<subject>`, or
+3. reply with a single {% numeric RPL_HELPSTART %} message, then arbitrarily many {% numeric RPL_HELPTXT %} messages, then a single {% numeric RPL_ENDOFHELP %}.
+
+Servers MAY use the third option even on unknown `<subject>`; especially if their reply would not fit in a single line.
+
+It is recommended for the {% numeric RPL_HELPSTART %} message to be some sort of title and for the first {% numeric RPL_HELPTXT %} message to be empty; as if the help was part of a longer document.
+
+Servers may define any `<subject>` they want.
+Servers typically have documentation for most of the IRC commands they support.
+
+Clients SHOULD gracefully handle legacy servers that reply to `HELP` using a set of {% command NOTICE %}.
+On these servers, they may try the `HELPOP` command instead (with the same syntax), which may return the numeric-based type of reply.
+
+Numerics:
+
+* {% numeric ERR_UNKNOWNCOMMAND %}
+* {% numeric ERR_HELPNOTFOUND %}
+* {% numeric RPL_HELPSTART %}
+* {% numeric RPL_HELPTXT %}
+* {% numeric RPL_ENDOFHELP %}
+
+Command Examples:
+
+      HELP                                                     ; request generic help
+      :server 704 val * :** Help System **                     ; first line
+      :server 705 val * :
+      :server 705 val * :Try /HELP <command> for specific help,
+      :server 705 val * :/HELP USERCMDS to list available
+      :server 706 val * :commands, or join the #help channel   ; last line
+
+      HELP PRIVMSG                                             ; request help on PRIVMSG
+      :server 704 val PRIVMSG :** The PRIVMSG command **
+      :server 705 val PRIVMSG :
+      :server 705 val PRIVMSG :The /PRIVMSG command is the main way
+      :server 706 val PRIVMSG :to send messages to other users.
+
+      HELP :unknown subject                                    ; request help on "unknown subject"
+      :server 524 val * :I do not know anything about this
+
+      HELP :unknown subject
+      :server 704 val * :** Help System **
+      :server 705 val * :
+      :server 705 val * :I do not know anything about this.
+      :server 705 val * :
+      :server 705 val * :Try /HELP USERCMDS to list available
+      :server 706 val * :commands, or join the #help channel
+
 ### INFO message
 
          Command: INFO

--- a/index.md
+++ b/index.md
@@ -1245,6 +1245,8 @@ Servers typically have documentation for most of the IRC commands they support.
 Clients SHOULD gracefully handle older servers that reply to `HELP` with a set of {% command NOTICE %} messages.
 On these servers, the client may try sending the `HELPOP` command (with the same syntax specified here), which may return the numeric-based reply.
 
+Clients SHOULD also gracefully handle servers that reply to `HELP` with a set of `290`/`291`/`292`/`293`/`294`/`295` numerics.
+
 Numerics:
 
 * {% numeric ERR_HELPNOTFOUND %}

--- a/index.md
+++ b/index.md
@@ -1234,25 +1234,19 @@ Command Examples:
       Parameters: [<subject>]
 
 The `HELP` command is used to return documentation about the IRC server and the IRC commands it implements.
-When receiving an `HELP` command, servers MUST either:
 
-1. reply with {% numeric ERR_UNKNOWNCOMMAND %} if they don't support the command at all,
-2. reply with a single {% numeric ERR_HELPNOTFOUND %} message if they do not know about the `<subject>`, or
-3. reply with a single {% numeric RPL_HELPSTART %} message, then arbitrarily many {% numeric RPL_HELPTXT %} messages, then a single {% numeric RPL_ENDOFHELP %}.
+When receiving a `HELP` command, servers MUST either: reply with a single {% numeric ERR_HELPNOTFOUND %} message; or reply with a single {% numeric RPL_HELPSTART %} message, then arbitrarily many {% numeric RPL_HELPTXT %} messages, then a single {% numeric RPL_ENDOFHELP %}. Servers MAY return the {% numeric RPL_HELPTXT %} form for unknown subjects, especially if their reply would not fit in a single line.
 
-Servers MAY use the third option even on unknown `<subject>`; especially if their reply would not fit in a single line.
+The {% numeric RPL_HELPSTART %} message SHOULD be some sort of title and the first {% numeric RPL_HELPTXT %} message SHOULD be empty. This is what most servers do today.
 
-It is recommended for the {% numeric RPL_HELPSTART %} message to be some sort of title and for the first {% numeric RPL_HELPTXT %} message to be empty; as if the help was part of a longer document.
-
-Servers may define any `<subject>` they want.
+Servers MAY define any `<subject>` they want.
 Servers typically have documentation for most of the IRC commands they support.
 
-Clients SHOULD gracefully handle legacy servers that reply to `HELP` using a set of {% command NOTICE %}.
-On these servers, they may try the `HELPOP` command instead (with the same syntax), which may return the numeric-based type of reply.
+Clients SHOULD gracefully handle older servers that reply to `HELP` with a set of {% command NOTICE %} messages.
+On these servers, the client may try sending the `HELPOP` command (with the same syntax specified here), which may return the numeric-based reply.
 
 Numerics:
 
-* {% numeric ERR_UNKNOWNCOMMAND %}
 * {% numeric ERR_HELPNOTFOUND %}
 * {% numeric RPL_HELPSTART %}
 * {% numeric RPL_HELPTXT %}


### PR DESCRIPTION
With the provision about legacy servers using NOTICE, this seems to cover
every IRCd (Bahamut, Ergo, Hybrid/Chary/etc, InspIRCd, irc2, ircu2, ngircd)
except Unreal, which uses other numerics.