### PR TITLE
Make user & host mandatory in the NUH

### DIFF
--- a/index.md
+++ b/index.md
@@ -321,7 +321,7 @@ For more information on processing tags – including the naming and registratio
 
 ### Source
 
-      source          ::=  servername / ( nickname [ "!" user ] [ "@" host ] )
+      source          ::=  servername / ( nickname "!" user "@" host )
 
 The **source** (formerly known as **prefix**) is optional and starts with a `(':', 0x3A)` character (which is stripped from the value), and if there are no tags it MUST be the first character of the message itself.
 
@@ -331,6 +331,9 @@ Clients MUST NOT include a source when sending a message.
 
 Servers MAY include a source on any message, and MAY leave a source off of any message. Clients MUST be able to process any given message the same way whether it contains a source or does not contain one.
 
+The following relaxed syntax used to be sent by some servers, and clients MAY accept it:
+
+      source          ::=  servername / ( nickname [ "!" user ] [ "@" host ] )
 
 ### Command
 


### PR DESCRIPTION
It breaks too many clients not to include it, so it's unreasonable
to document is as optional.