### PR TITLE
Fix typo in numeric tag

### DIFF
--- a/index.md
+++ b/index.md
@@ -736,7 +736,7 @@ If a client's `JOIN` command to the server is successful, the server MUST send, 
 
 1. A `JOIN` message with the client as the message `<source>` and the channel they have joined as the first parameter of the message.
 2. The channel's topic (with {% numeric RPL_TOPIC %} and optionally {% numeric RPL_TOPICWHOTIME %}), and no message if the channel does not have a topic.
-3. A list of users currently joined to the channel (with one or more {% numeric RPL_NAMREPLY %} numerics followed by a single {% numerics RPL_ENDOFNAMES %} numeric). These `RPL_NAMREPLY` messages sent by the server MUST include the requesting client that has just joined the channel.
+3. A list of users currently joined to the channel (with one or more {% numeric RPL_NAMREPLY %} numerics followed by a single {% numeric RPL_ENDOFNAMES %} numeric). These `RPL_NAMREPLY` messages sent by the server MUST include the requesting client that has just joined the channel.
 
 The [key](#key-channel-mode), [client limit](#client-limit-channel-mode) , [ban](#ban-channel-mode) - [exemption](#ban-exemption-channel-mode), [invite-only](#invite-only-channel-mode) - [exemption](#invite-exemption-channel-mode), and other (depending on server software) channel modes affect whether or not a given client may join a channel. More information on each of these modes and how they affect the `JOIN` command is available in their respective sections.
 


### PR DESCRIPTION
Fixes the following issue:

    Liquid Exception: Liquid syntax error (line 715): Unknown tag 'numerics' in index.md