### PR TITLE
Unspecify the <target> argument of INFO

### DIFF
--- a/index.md
+++ b/index.md
@@ -1158,30 +1158,20 @@ Command Examples:
 ### INFO message
 
          Command: INFO
-      Parameters: [<target>]
+      Parameters: None
 
 The `INFO` command is used to return information which describes the specified server. This information usually includes the software name/version and its authors. Some other info that may be returned includes the patch level and compile date of the server, the copyright on the server software, and whatever miscellaneous information the server authors consider relevant.
-
-If `<target>` is not given, the server handling the command must reply to the query. If `<target>` is given and a matching server cannot be found, the server will respond with the `ERR_NOSUCHSERVER` numeric and the command will fail.
 
 Upon receiving an `INFO` command, the given server will respond with zero or more `RPL_INFO` replies, followed by one `RPL_ENDOFINFO` numeric.
 
 Numeric Replies:
 
-* {% numeric ERR_NOSUCHSERVER %}
 * {% numeric RPL_INFO %}
 * {% numeric RPL_ENDOFINFO %}
 
 Command Examples:
 
-     INFO csd.bu.edu                 ; request an INFO reply from
-                                     csd.bu.edu
-
-     :Avalon INFO *.fi               ; INFO request from Avalon for first
-                                     server found to match *.fi.
-
-     INFO Angel                      ; request info from the server that
-                                     Angel is connected to.
+     INFO                            ; request info from the server
 
 ### MODE message
 


### PR DESCRIPTION
As @SadieCat pointed out at <https://github.com/inspircd/inspircd/issues/1943>,
it's not very useful and Insp will probably drop it.

Unreal already ignores the argument when it comes from non-opers:
<https://bugs.unrealircd.org/view.php?id=6004>