### PR TITLE
Specify LUSERS

### DIFF
--- a/index.md
+++ b/index.md
@@ -1083,6 +1083,27 @@ Command Examples:
       CONNECT  eff.org 12765 csd.bu.edu
       ; Attempt to connect csu.bu.edu to eff.org on port 12765
 
+### LUSERS message
+
+         Command: LUSERS
+      Parameters: None
+
+Returns statistics about local and global users, as numeric replies.
+
+Servers MUST reply with `RPL_LUSERCLIENT` and `RPL_LUSERME`, and SHOULD also include
+all those defined below.
+
+Clients SHOULD NOT try to parse the free-form text in the trailing parameter,
+and rely on specific parameters instead.
+
+* {% numeric RPL_LUSERCLIENT %}
+* {% numeric RPL_LUSEROP %}
+* {% numeric RPL_LUSERUNKNOWN %}
+* {% numeric RPL_LUSERCHANNELS %}
+* {% numeric RPL_LUSERME %}
+* {% numeric RPL_LOCALUSERS %}
+* {% numeric RPL_GLOBALUSERS %}
+
 ### TIME message
 
          Command: TIME


### PR DESCRIPTION
This is simplified compared to RFC2812, as this removes the mask and target. As far as I'm aware, these parameters are completely unused, and probably not implemented.

The reason all numerics are not a MUST is because ircu2 and snircd don't send most of them.

Resolves GH-145.