### PR TITLE
Specify how to handle broken messages.

### DIFF
--- a/_includes/modern-appendix.md
+++ b/_includes/modern-appendix.md
@@ -668,12 +668,6 @@ Sent to a client which has just successfully issued an {% message OPER %} comman
 
 Sent to an [operator](#operators) which has just successfully issued a {% message REHASH %} command. The text used in the last param of this message may vary.
 
-{% numericheader ERR_INPUTTOOLONG %}
-
-      "<client> :Input line was too long"
-
-Indicates a given line does not follow the specified size limits (512 bytes for the main section, 4094 or 8191 bytes for the tag section).
-
 {% numericheader ERR_UNKNOWNERROR %}
 
       "<client> <command>{ <subcommand>} :<info>"
@@ -728,6 +722,12 @@ Indicates that the `JOIN` command failed because the client has joined their max
 
 Indicates a PING or PONG message missing the originator parameter which is required by old IRC servers.
 Nowadays, this may be used by some servers when the PING `<token>` is empty.
+
+{% numericheader ERR_INPUTTOOLONG %}
+
+      "<client> :Input line was too long"
+
+Indicates a given line does not follow the specified size limits (512 bytes for the main section, 4094 or 8191 bytes for the tag section).
 
 {% numericheader ERR_UNKNOWNCOMMAND %}
 

--- a/_includes/modern-appendix.md
+++ b/_includes/modern-appendix.md
@@ -668,6 +668,12 @@ Sent to a client which has just successfully issued an {% message OPER %} comman
 
 Sent to an [operator](#operators) which has just successfully issued a {% message REHASH %} command. The text used in the last param of this message may vary.
 
+{% numericheader ERR_INPUTTOOLONG %}
+
+      "<client> :Input line was too long"
+
+Indicates a given line does not follow the specified size limits (512 bytes for the main section, 4094 or 8191 bytes for the tag section).
+
 {% numericheader ERR_UNKNOWNERROR %}
 
       "<client> <command>{ <subcommand>} :<info>"

--- a/index.md
+++ b/index.md
@@ -374,7 +374,7 @@ As these examples show, a trailing parameter (a final parameter with a preceding
 
 ### Compatibility with incorrect software
 
-Servers SHOULD handle single `\r` or `\n` character as if it was a `\r\n` pair, to support existing clients that might send this. However, clients and servers alike MUST NOT send single `\r` or `\n` characters.
+Servers SHOULD handle single `\n` character, and MAY handle a single `\r` character, as if it was a `\r\n` pair, to support existing clients that might send this. However, clients and servers alike MUST NOT send single `\r` or `\n` characters.
 
 Servers and clients SHOULD ignore empty lines.
 

--- a/index.md
+++ b/index.md
@@ -380,7 +380,7 @@ Servers and clients SHOULD ignore empty lines.
 
 Servers SHOULD gracefully handle messages over the 512-bytes limit. They may:
 
-* Send an error numeric back.
+* Send an error numeric back, preferably {% numeric ERR_INPUTTOOLONG %}
 * Truncate on the 510th byte (and add `\r\n` at the end) or, preferably, on the last UTF-8 character or grapheme that fits.
 * Ignore the message or close the connection – but this may be confusing to users of buggy clients.
 

--- a/index.md
+++ b/index.md
@@ -372,6 +372,17 @@ Here are some examples of messages and how the parameters would be represented a
 
 As these examples show, a trailing parameter (a final parameter with a preceding `':'`) has the same semantics as any other parameter, and MUST NOT be treated specially or stored separately once the `':'` is stripped.
 
+### Compatibility with incorrect software
+
+Servers SHOULD handle single `\r` or `\n` character as if it was a `\r\n` pair, to support existing clients that might send this. However, clients and servers alike MUST NOT send single `\r` or `\n` characters.
+
+Servers and clients SHOULD ignore empty lines.
+
+Servers SHOULD gracefully handle messages over the 512-bytes limit. This includes:
+
+* sending an error numeric back
+* truncating on the 510th byte (and adding `\r\n` at the end) or the last UTF-8 character or grapheme that fits.
+* ignoring the message or closing the connection, but this may be confusing to users of buggy clients.
 
 ## Numeric Replies
 

--- a/index.md
+++ b/index.md
@@ -378,11 +378,11 @@ Servers SHOULD handle single `\r` or `\n` character as if it was a `\r\n` pair, 
 
 Servers and clients SHOULD ignore empty lines.
 
-Servers SHOULD gracefully handle messages over the 512-bytes limit. This includes:
+Servers SHOULD gracefully handle messages over the 512-bytes limit. They may:
 
-* sending an error numeric back
-* truncating on the 510th byte (and adding `\r\n` at the end) or the last UTF-8 character or grapheme that fits.
-* ignoring the message or closing the connection, but this may be confusing to users of buggy clients.
+* Send an error numeric back.
+* Truncate on the 510th byte (and add `\r\n` at the end) or on the last UTF-8 character or grapheme that fits.
+* Ignore the message or close the connection – but this may be confusing to users of buggy clients.
 
 ## Numeric Replies
 

--- a/index.md
+++ b/index.md
@@ -381,7 +381,7 @@ Servers and clients SHOULD ignore empty lines.
 Servers SHOULD gracefully handle messages over the 512-bytes limit. They may:
 
 * Send an error numeric back.
-* Truncate on the 510th byte (and add `\r\n` at the end) or on the last UTF-8 character or grapheme that fits.
+* Truncate on the 510th byte (and add `\r\n` at the end) or, preferably, on the last UTF-8 character or grapheme that fits.
 * Ignore the message or close the connection – but this may be confusing to users of buggy clients.
 
 ## Numeric Replies

--- a/index.md
+++ b/index.md
@@ -384,6 +384,8 @@ Servers SHOULD gracefully handle messages over the 512-bytes limit. They may:
 * Truncate on the 510th byte (and add `\r\n` at the end) or, preferably, on the last UTF-8 character or grapheme that fits.
 * Ignore the message or close the connection – but this may be confusing to users of buggy clients.
 
+Finally, clients and servers SHOULD NOT use more than one space (`\x20`) character as `SPACE` as defined in the grammar above.
+
 ## Numeric Replies
 
 Most messages sent from a client to a server generates a reply of some sort. The most common form of reply is the numeric reply, used for both errors and normal replies. Distinct from a normal message, a numeric reply MUST contain a `<source>` and use a three-digit numeric as the command. A numeric reply SHOULD contain the target of the reply as the first parameter of the message. A numeric reply is not allowed to originate from a client.


### PR DESCRIPTION
Handling of oversized messages in clients is intentionally left unspecified,
because I don't think it makes much sense to specify it as it's a UI issue.

Closes GH-92.

Also specify that the SPACE between verb/params/... should not be more than one char. Closes GH-94.