### PR TITLE
Specify WHOWAS

### DIFF
--- a/_includes/messages/user_queries.md
+++ b/_includes/messages/user_queries.md
@@ -115,3 +115,54 @@ Reply Example:
       :calcium.libera.chat 330 val val pinkieval :is logged in as
       :calcium.libera.chat 318 val val :End of /WHOIS list.
 
+### WHOWAS message
+
+         Command: WHOWAS
+      Parameters: <nick> [<count>]
+
+Whowas asks for information about a nickname which no longer exists.
+This may either be due to a nickname change or the user leaving IRC.
+In response to this query, the server searches through its nickname history, looking for any nicks which are lexically the same (no wild card matching here).
+The history is searched backward, returning the most recent entry first.
+If there are multiple entries, up to `<count>` replies will be returned (or all of them if no `<count>` parameter is given).
+
+If given, `<count>` SHOULD be a non-positive number. Otherwise, a full search is done.
+
+Servers MUST reply with either {% numeric ERR_WASNOSUCHNICK %} or a non-empty list of WHOWAS entries,
+both followed with {% numeric RPL_ENDOFWHOWAS %}
+
+A WHOWAS entry is a series of numeric messages starting with {% numeric RPL_WHOWASUSER %}, optionally followed by other numerics relevant to that user, such as {% numeric RPL_WHOISACTUALLY %} and {% numeric RPL_WHOISSERVER %}.
+Clients MUST NOT assume any particular numeric other than {% numeric RPL_WHOWASUSER %} is present in a WHOWAS entry.
+
+If the `<nick>` argument is missing, they SHOULD send a single reply, using either {% numeric ERR_NONICKNAMEGIVEN %} or {% numeric ERR_NEEDMOREPARAMS %}.
+
+#### Examples
+
+Command Examples:
+
+      WHOWAS someone
+      WHOWAS someone 2
+
+Reply Examples:
+
+      :inspircd.server.example 314 val someone ident3 127.0.0.1 * :Realname
+      :inspircd.server.example 312 val someone My.Little.Server :Sun Mar 20 2022 10:59:26
+      :inspircd.server.example 314 val someone ident2 127.0.0.1 * :Realname
+      :inspircd.server.example 312 val someone My.Little.Server :Sun Mar 20 2022 10:59:16
+      :inspircd.server.example 369 val someone :End of WHOWAS
+
+      :ergo.server.example 314 val someone ~ident3 127.0.0.1 * Realname
+      :ergo.server.example 314 val someone ~ident2 127.0.0.1 * Realname
+      :ergo.server.example 369 val someone :End of WHOWAS
+
+      :solanum.server.example 314 val someone ~ident3 localhost * :Realname
+      :solanum.server.example 338 val someone 127.0.0.1 :actually using host
+      :solanum.server.example 312 val someone solanum.server.example :Sun Mar 20 10:07:44 2022
+      :solanum.server.example 314 val someone ~ident2 localhost * :Realname
+      :solanum.server.example 338 val someone 127.0.0.1 :actually using host
+      :solanum.server.example 312 val someone solanum.server.example :Sun Mar 20 10:07:34 2022
+      :solanum.server.example 369 val someone :End of WHOWAS
+
+      :server.example 406 val someone :There was no such nickname
+      :server.example 369 val someone :End of WHOWAS
+

--- a/_includes/modern-appendix.md
+++ b/_includes/modern-appendix.md
@@ -454,7 +454,7 @@ Sent as a reply to the {% message WHOIS %} command, this numeric shows details a
 
       "<client> <nick> <server> :<server info>"
 
-Sent as a reply to the {% message WHOIS %} command, this numeric shows which server the client with the nickname `<nick>` is connected to. `<server>` is the name of the server (as used in message prefixes). `<server info>` is a string containing a description of that server.
+Sent as a reply to the {% message WHOIS %} (or {% message WHOWAS %}) command, this numeric shows which server the client with the nickname `<nick>` is (or was) connected to. `<server>` is the name of the server (as used in message prefixes). `<server info>` is a string containing a description of that server.
 
 {% numericheader RPL_WHOISOPERATOR %}
 
@@ -466,7 +466,7 @@ Sent as a reply to the {% message WHOIS %} command, this numeric indicates that 
 
       "<client> <nick> <username> <host> * :<realname>"
 
-Sent as a reply to the {% message WHOWAS %} command, this numeric shows details about the last client that used the nickname `<nick>`. The purpose of each argument is the same as with the {% numeric RPL_WHOISUSER %} numeric.
+Sent as a reply to the {% message WHOWAS %} command, this numeric shows details about one of the last clients that used the nickname `<nick>`. The purpose of each argument is the same as with the {% numeric RPL_WHOISUSER %} numeric.
 
 {% numericheader RPL_WHOISIDLE %}
 
@@ -563,7 +563,7 @@ Sent to a client to let them know who set the topic (`<nick>`) and when they set
       "<client> <nick> <host|ip> :Is actually using host"
       "<client> <nick> <username>@<hostname> <ip> :Is actually using host"
 
-Sent as a reply to the {% command WHOIS %} command, this numeric shows details about the client with the nickname `<nick>`.
+Sent as a reply to the {% command WHOIS %} and {% command WHOWAS %} commands, this numeric shows details about the client with the nickname `<nick>`.
 
 `<username>` represents the name set by the {% command USER %} command (though `<username>` may be set by the server in other ways).
 
@@ -761,6 +761,13 @@ This is generally sent in response to channel modes, such as a channel being [mo
       "<client> <channel> :You have joined too many channels"
 
 Indicates that the `JOIN` command failed because the client has joined their maximum number of channels. The text used in the last param of this message may vary.
+
+{% numericheader ERR_WASNOSUCHNICK %}
+
+      "<client> :There was no such nickname"
+
+Returned as a reply to {% message WHOWAS %} to indicate there is no history information for that nickname.
+
 
 {% numericheader ERR_NOORIGIN %}
 


### PR DESCRIPTION
The syntax and base description are copied from
https://datatracker.ietf.org/doc/html/rfc1459#section-4.5.3
with two changes:

1. removed `<server>` because it is pointless
2. "`<count>` SHOULD be a non-positive number" because one
   implementation (ircu2) does not handle `0` the same way others do.
   (besides, there is no reason for clients to send that)

I ignored https://datatracker.ietf.org/doc/html/rfc2812#section-3.6.3
because noone seems to implement wildcards, and the only implementation
supporting TARGMAX WHOWAS (Bahamut) does not follow the spec (it returns
replies in query order instead of chronological order)

I added a description of replies, that matches every implementation I
could find.
In particular, I made it a requirement that `RPL_WHOWASUSER` must come
first, because otherwise it would be hell for clients to parse this.

Finally, I made it explicit that `RPL_ENDOFWHOWAS` should not be used
when the nick is missing, to match existing implementations (as opposed
to what the RFCs say).