### PR TITLE
add client_prefix to tags' key

### DIFF
--- a/_includes/c2s_structure.md
+++ b/_includes/c2s_structure.md
@@ -48,7 +48,8 @@ This is the format of the **tags** part:
 
       <tags>          ::= <tag> [';' <tag>]*
       <tag>           ::= <key> ['=' <escaped value>]
-      <key>           ::= [ <vendor> '/' ] <sequence of letters, digits, hyphens (`-`)>
+      <key>           ::= [ <client_prefix> ] [ <vendor> '/' ] <sequence of letters, digits, hyphens (`-`)>
+      <client_prefix> ::= '+'
       <escaped value> ::= <sequence of any characters except NUL, CR, LF, semicolon (`;`) and SPACE>
       <vendor>        ::= <host>
 


### PR DESCRIPTION
Message Tags Specification stands you may have optional client_prefix in tags' key: https://ircv3.net/specs/extensions/message-tags.html#format