### PR TITLE
Specify LINKS

### DIFF
--- a/_includes/messages/optional.md
+++ b/_includes/messages/optional.md
@@ -22,6 +22,22 @@ Numeric Replies:
 * {% numeric RPL_UNAWAY %}
 * {% numeric RPL_NOWAWAY %}
 
+### LINKS message
+
+         Command: LINKS
+      Parameters: None
+
+With LINKS, a user can list all servers which are known by the server answering the query, usually including the server itself.
+
+In replying to the LINKS message, a server MUST send replies back using zero or more {% numeric RPL_LINKS %} messages and mark the end of the list using a {% numeric RPL_ENDOFLINKS %} message.
+
+Servers MAY omit some or all servers on the network, including itself.
+
+Numeric Replies:
+
+* {% numeric RPL_LINKS %}
+* {% numeric RPL_ENDOFLINKS %}
+
 ### USERHOST message
 
          Command: USERHOST

--- a/_includes/messages/server_queries.md
+++ b/_includes/messages/server_queries.md
@@ -99,7 +99,7 @@ Command Examples:
 
 ### LINKS message
 
-         Command: LUSERS
+         Command: LINKS
       Parameters: None
 
 With LINKS, a user can list all servers which are known by the server answering the query, usually including the server itself.

--- a/_includes/messages/server_queries.md
+++ b/_includes/messages/server_queries.md
@@ -97,6 +97,23 @@ Command Examples:
       CONNECT  eff.org 12765 csd.bu.edu
       ; Attempt to connect csu.bu.edu to eff.org on port 12765
 
+### LINKS message
+
+         Command: LUSERS
+      Parameters: None
+
+With LINKS, a user can list all servers which are known by the server answering the query, usually including the server itself.
+
+In replying to the LINKS message, a server MUST send replies back using 0 or more {% numeric RPL_LINKS %} messages and mark the end of the list using a {% numeric RPL_ENDOFLINKS %} message.
+
+Servers MAY omit some or all servers on the network, including itself.
+
+Numeric Replies:
+
+* {% numeric ERR_NOSUCHCOMMAND %}
+* {% numeric RPL_LINKS %}
+* {% numeric RPL_ENDOFLINKS %}
+
 ### LUSERS message
 
          Command: LUSERS

--- a/_includes/messages/server_queries.md
+++ b/_includes/messages/server_queries.md
@@ -97,23 +97,6 @@ Command Examples:
       CONNECT  eff.org 12765 csd.bu.edu
       ; Attempt to connect csu.bu.edu to eff.org on port 12765
 
-### LINKS message
-
-         Command: LINKS
-      Parameters: None
-
-With LINKS, a user can list all servers which are known by the server answering the query, usually including the server itself.
-
-In replying to the LINKS message, a server MUST send replies back using zero or more {% numeric RPL_LINKS %} messages and mark the end of the list using a {% numeric RPL_ENDOFLINKS %} message.
-
-Servers MAY omit some or all servers on the network, including itself.
-
-Numeric Replies:
-
-* {% numeric ERR_UNKNOWNCOMMAND %}
-* {% numeric RPL_LINKS %}
-* {% numeric RPL_ENDOFLINKS %}
-
 ### LUSERS message
 
          Command: LUSERS

--- a/_includes/messages/server_queries.md
+++ b/_includes/messages/server_queries.md
@@ -104,7 +104,7 @@ Command Examples:
 
 With LINKS, a user can list all servers which are known by the server answering the query, usually including the server itself.
 
-In replying to the LINKS message, a server MUST send replies back using 0 or more {% numeric RPL_LINKS %} messages and mark the end of the list using a {% numeric RPL_ENDOFLINKS %} message.
+In replying to the LINKS message, a server MUST send replies back using zero or more {% numeric RPL_LINKS %} messages and mark the end of the list using a {% numeric RPL_ENDOFLINKS %} message.
 
 Servers MAY omit some or all servers on the network, including itself.
 

--- a/_includes/messages/server_queries.md
+++ b/_includes/messages/server_queries.md
@@ -110,7 +110,7 @@ Servers MAY omit some or all servers on the network, including itself.
 
 Numeric Replies:
 
-* {% numeric ERR_NOSUCHCOMMAND %}
+* {% numeric ERR_UNKNOWNCOMMAND %}
 * {% numeric RPL_LINKS %}
 * {% numeric RPL_ENDOFLINKS %}
 

--- a/_includes/modern-appendix.md
+++ b/_includes/modern-appendix.md
@@ -627,6 +627,20 @@ Sent as a reply to the {% message NAMES %} command, this numeric lists the clien
 
 Sent as a reply to the {% message NAMES %} command, this numeric specifies the end of a list of channel member names.
 
+{% numericheader RPL_LINKS %}
+
+      "<client> * <server> :<hopcount> <server info>"
+
+Sent as a reply to the {% message LINKS %} command, this numeric specifies one of the known servers on the network.
+
+`<server info>` is a string containing a description of that server.
+
+{% numericheader RPL_ENDOFLINKS %}
+
+      "<client> * :End of /LINKS list"
+
+Sent as a reply to the {% message LINKS %} command, this numeric specifies the end of a list of channel member names.
+
 {% numericheader RPL_BANLIST %}
 
       "<client> <channel> <mask> [<who> <set-ts>]"


### PR DESCRIPTION
Based on https://datatracker.ietf.org/doc/html/rfc1459#section-4.3.3 and https://datatracker.ietf.org/doc/html/rfc2812#section-3.4.5 , but I removed the optional arguments, because they don't seem to be implemented anymore.