### PR TITLE
Clarify the situation on INVITELIST and INVEXLIST.

### DIFF
--- a/_data/modern.yml
+++ b/_data/modern.yml
@@ -314,6 +314,12 @@ numerics:
   RPL_TOPICWHOTIME:
     numeric: '333'
 
+  RPL_INVITELIST:
+    numeric: '336'
+
+  RPL_ENDOFINVITELIST:
+    numeric: '337'
+
   RPL_WHOISACTUALLY:
     numeric: '338'
 
@@ -326,10 +332,10 @@ numerics:
   RPL_WHOISKILL:
     numeric: '343'
 
-  RPL_INVITELIST:
+  RPL_INVEXLIST:
     numeric: '346'
 
-  RPL_ENDOFINVITELIST:
+  RPL_ENDOFINVEXLIST:
     numeric: '347'
 
   RPL_EXCEPTLIST:

--- a/_includes/messages/channel.md
+++ b/_includes/messages/channel.md
@@ -187,7 +187,6 @@ Command Examples:
 
          Command: INVITE
       Parameters: <nickname> <channel>
-      Alt Params: 0
 
 The `INVITE` command is used to invite a user to a channel.  The parameter `<nickname>` is the nickname of the person to be invited to the target channel `<channel>`.
 
@@ -218,6 +217,16 @@ Message Examples:
 
       :dan-!d@localhost INVITE Wiz #test    ; dan- has invited Wiz
                                             to the channel #test
+
+#### Invite list
+
+Servers MAY allow the `INVITE` with no parameter, and reply with a list of channels the sender is invited to as {% numeric RPL_INVITELIST %} numerics, ending with a {% numeric RPL_ENDOFINVITELIST %} numeric.
+
+<div class="warning">
+    <p>A widespread bug in old implementations is to use numerics 346/347 instead of 336/337 as `RPL_INVITELIST`/`RPL_ENDOFINVITELIST`, due to ambiguous legacy specifications. You should check the server you are using implements them as expected.</p>
+
+    <p>346/347 now stands for `RPL_INVEXLIST`/`RPL_ENDOFINVEXLIST`, used for <a href="#invite-exemption-channel-mode">invite-exemption list</a>.</p>
+</div>
 
 ### KICK message
 

--- a/_includes/messages/channel.md
+++ b/_includes/messages/channel.md
@@ -223,9 +223,9 @@ Message Examples:
 Servers MAY allow the `INVITE` with no parameter, and reply with a list of channels the sender is invited to as {% numeric RPL_INVITELIST %} numerics, ending with a {% numeric RPL_ENDOFINVITELIST %} numeric.
 
 <div class="warning">
-    <p>A widespread bug in old implementations is to use numerics 346/347 instead of 336/337 as `RPL_INVITELIST`/`RPL_ENDOFINVITELIST`, due to ambiguous legacy specifications. You should check the server you are using implements them as expected.</p>
+    <p>Some rare implementations use numerics 346/347 instead of 336/337 as `RPL_INVITELIST`/`RPL_ENDOFINVITELIST`. You should check the server you are using implements them as expected.</p>
 
-    <p>346/347 now stands for `RPL_INVEXLIST`/`RPL_ENDOFINVEXLIST`, used for <a href="#invite-exemption-channel-mode">invite-exemption list</a>.</p>
+    <p>346/347 now generally stands for `RPL_INVEXLIST`/`RPL_ENDOFINVEXLIST`, used for <a href="#invite-exemption-channel-mode">invite-exemption list</a>.</p>
 </div>
 
 ### KICK message

--- a/_includes/modern-appendix.md
+++ b/_includes/modern-appendix.md
@@ -577,17 +577,25 @@ See also: {% numeric RPL_WHOISHOST %}, for similar semantics on other servers.
 
 Sent as a reply to the {% message INVITE %} command to indicate that the attempt was successful and the client with the nickname `<nick>` has been invited to `<channel>`.
 
-{% numericheader RPL_INVITELIST %}
+{% numericheader RPL_INVEXLIST %}
 
       "<client> <channel> <mask>"
 
 Sent as a reply to the {% message MODE %} command, when clients are viewing the current entries on a channel's [invite-exception list](#invite-exception-channel-mode). `<mask>` is the given mask on the invite-exception list.
 
-{% numericheader RPL_ENDOFINVITELIST %}
+This numeric should not be confused with {% numeric RPL_INVITELIST %}, which is used as a reply to {% message INVITE %}.
+
+This numeric is sometimes erroneously called `RPL_INVITELIST`, as this was the name used in RFC2812.
+
+{% numericheader RPL_ENDOFINVEXLIST %}
 
       "<client> <channel> :End of channel invite list"
 
 Sent as a reply to the {% message MODE %} command, this numeric indicates the end of a channel's [invite-exception list](#invite-exception-channel-mode).
+
+This numeric should not be confused with {% numeric RPL_ENDOFINVITELIST %}, which is used as a reply to {% message INVITE %}.
+
+This numeric is sometimes erroneously called `RPL_ENDOFINVITELIST`, as this was the name used in RFC2812.
 
 {% numericheader RPL_EXCEPTLIST %}
 

--- a/_includes/modern-appendix.md
+++ b/_includes/modern-appendix.md
@@ -572,7 +572,7 @@ This numeric should not be confused with {% numeric RPL_INVEXLIST %}, which is u
 
 {% numericheader RPL_ENDOFINVITELIST %}
 
-      "<client> <channel> :End of Channel Invite Exception List"
+      "<client> :End of /INVITE list"
 
 Sent as a reply to the {% message INVITE %} command when used with no parameter, this numeric indicates the end of invitations a client received.
 
@@ -614,7 +614,7 @@ This numeric is sometimes erroneously called `RPL_INVITELIST`, as this was the n
 
 {% numericheader RPL_ENDOFINVEXLIST %}
 
-      "<client> <channel> :End of channel invite list"
+      "<client> <channel> :End of Channel Invite Exception List"
 
 Sent as a reply to the {% message MODE %} command, this numeric indicates the end of a channel's [invite-exception list](#invite-exception-channel-mode).
 

--- a/_includes/modern-appendix.md
+++ b/_includes/modern-appendix.md
@@ -557,6 +557,31 @@ Sent to a client when joining the `<channel>` to inform them of the current [top
 
 Sent to a client to let them know who set the topic (`<nick>`) and when they set it (`<setat>` is a unix timestamp). Sent after {% numeric RPL_TOPIC %}.
 
+{% numericheader RPL_INVITELIST %}
+
+      "<client> <channel>"
+
+Sent to a client as a reply to the {% command INVITE %} command when used with no parameter, to indicate a channel the client was invited to.
+
+This numeric should not be confused with {% numeric RPL_INVEXLIST %}, which is used as a reply to {% message MODE %}.
+
+
+<div class="warning">
+    <p>Some rare implementations use 346 instead of 336 for this reply.</p>
+</div>
+
+{% numericheader RPL_ENDOFINVITELIST %}
+
+      "<client> <channel> :End of Channel Invite Exception List"
+
+Sent as a reply to the {% message INVITE %} command when used with no parameter, this numeric indicates the end of invitations a client received.
+
+This numeric should not be confused with {% numeric RPL_ENDOFINVEXLIST %}, which is used as a reply to {% message MODE %}.
+
+<div class="warning">
+    <p>Some rare implementations use 347 instead of 337 for this reply.</p>
+</div>
+
 {% numericheader RPL_WHOISACTUALLY %}
 
       "<client> <nick> :is actually ..."


### PR DESCRIPTION
Every server I tested conforms to this (when they implement the feature) except ircu2; ~~but I sent them a PR to fix it.~~ (the PR was rejected, it's not a bug)

One notable exception is Hybrid, which always sends an empty INVITE list for some reason.

Closes GH-42.