### PR TITLE
Note that servers may not reply to WHOIS

### DIFF
--- a/_includes/messages/user_queries.md
+++ b/_includes/messages/user_queries.md
@@ -54,6 +54,8 @@ Servers MUST end their reply to `WHOIS` messages with one of these numerics:
 * {% numeric ERR_NONICKNAMEGIVEN %}
 * {% numeric RPL_ENDOFWHOIS %}otherwise, even if they did not send any other numeric message. This allows clients to stop waiting for new numerics.
 
+In exceptional error conditions, servers MAY not reply to a `WHOIS` command. Clients SHOULD implement a hard timeout to avoid waiting for a reply which won't come.
+
 Client MUST NOT not assume all numeric messages are sent at once, as server can interleave other messages before the end of the WHOIS response.
 
 If the `<target>` parameter is specified, it SHOULD be a server name or the nick of a user. Servers SHOULD send the query to a specific server with that name, or to the server `<target>` is connected to, respectively.


### PR DESCRIPTION
This can happen if a link between two servers is lost.