### PR TITLE
Include ERR_BADCHANMASK in JOIN

### DIFF
--- a/_includes/messages/channel.md
+++ b/_includes/messages/channel.md
@@ -37,6 +37,7 @@ Numeric Replies:
 * {% numeric ERR_BANNEDFROMCHAN %}
 * {% numeric ERR_CHANNELISFULL %}
 * {% numeric ERR_INVITEONLYCHAN %}
+* {% numeric ERR_BADCHANMASK %}
 * {% numeric RPL_TOPIC %}
 * {% numeric RPL_TOPICWHOTIME %}
 * {% numeric RPL_NAMREPLY %}


### PR DESCRIPTION
Given a bad name to create a new channel (i.e. without # at the beginning), server should reply with ERR_BADCHANMASK