### PR TITLE
Improve client nickname syntax description

### DIFF
--- a/_includes/concepts.md
+++ b/_includes/concepts.md
@@ -55,9 +55,10 @@ Nicknames are non-empty strings with the following restrictions:
 - They MUST NOT contain any of the following characters: space `(' ', 0x20)`, comma `(',', 0x2C)`, asterisk `('*', 0x2A)`, question mark `('?', 0x3F)`, exclamation mark `('!', 0x21)`, at sign `('@', 0x40)`.
 - They MUST NOT start with any of the following characters: dollar `('$', 0x24)`, colon `(':', 0x3A)`.
 - They MUST NOT start with a character listed as a [channel type](#channel-types) prefix.
+- They MUST NOT start with a character listed as a [channel membership prefix](#channel-membership-prefixes), or prefix listed in the IRCv3 [`multi-prefix` Extension](https://ircv3.net/specs/extensions/multi-prefix).
 - They SHOULD NOT contain any dot character `('.', 0x2E)`.
 
-Servers MAY have additional implementation-specific nickname restrictions.
+Servers MAY have additional implementation-specific nickname restrictions and SHOULD avoid the use of nicknames which are ambiguous with commands or command parameters where this could lead to confusion or error.
 
 ### Services
 

--- a/_includes/concepts.md
+++ b/_includes/concepts.md
@@ -54,8 +54,7 @@ Nicknames are non-empty strings with the following restrictions:
 
 - They MUST NOT contain any of the following characters: space `(' ', 0x20)`, comma `(',', 0x2C)`, asterisk `('*', 0x2A)`, question mark `('?', 0x3F)`, exclamation mark `('!', 0x21)`, at sign `('@', 0x40)`.
 - They MUST NOT start with any of the following characters: dollar `('$', 0x24)`, colon `(':', 0x3A)`.
-- They MUST NOT start with a character listed as a [channel type](#channel-types) prefix.
-- They MUST NOT start with a character listed as a [channel membership prefix](#channel-membership-prefixes), or prefix listed in the IRCv3 [`multi-prefix` Extension](https://ircv3.net/specs/extensions/multi-prefix).
+- They MUST NOT start with a character listed as a [channel type](#channel-types), [channel membership prefix](#channel-membership-prefixes), or prefix listed in the IRCv3 [`multi-prefix` Extension](https://ircv3.net/specs/extensions/multi-prefix).
 - They SHOULD NOT contain any dot character `('.', 0x2E)`.
 
 Servers MAY have additional implementation-specific nickname restrictions and SHOULD avoid the use of nicknames which are ambiguous with commands or command parameters where this could lead to confusion or error.


### PR DESCRIPTION
~~Align the text with RFC2812 which has a slightly more relaxed nickname syntax as RFC1459 and is the most commonly used one. I'm unsure why the modern documentation tries to be so loose and unspecific about this syntax considering it already clearly states "Servers MAY have additional implementation-specific nickname restrictions.".~~

List channel membership prefixes in the nickname as prohibited, and advise server implementations to avoid possible detrimental ambiguity.

Should solve #203