### PR TITLE
Drop ERR_NOSUCHSERVER from WHO replies

### DIFF
--- a/_includes/messages/user_queries.md
+++ b/_includes/messages/user_queries.md
@@ -19,7 +19,6 @@ Numeric Replies:
 
 * {% numeric RPL_WHOREPLY %}
 * {% numeric RPL_ENDOFWHO %}
-* {% numeric ERR_NOSUCHSERVER %}
 
 See also:
 


### PR DESCRIPTION
The WHO command doesn't have any server argument. It doesn't seem like any implementation returns ERR_NOSUCHSERVER.