### PR TITLE
Document ERR_INVALIDUSERNAME and ERR_ONLYSERVERSCANCHANGE

### DIFF
--- a/_data/modern.yml
+++ b/_data/modern.yml
@@ -608,6 +608,12 @@ numerics:
   ERR_KEYSET:
     numeric: '467'
 
+  ERR_ONLYSERVERSCANCHANGE:
+    numeric: '468'
+
+  ERR_INVALIDUSERNAME:
+    numeric: '468'
+
   ERR_LINKSET:
     numeric: '469'
 

--- a/_includes/messages/connection.md
+++ b/_includes/messages/connection.md
@@ -102,6 +102,7 @@ Numeric Replies:
 
 * {% numeric ERR_NEEDMOREPARAMS %}
 * {% numeric ERR_ALREADYREGISTERED %}
+* {% numeric ERR_INVALIDUSERNAME %}
 
 Command Examples:
 

--- a/_includes/messages/server_queries.md
+++ b/_includes/messages/server_queries.md
@@ -271,6 +271,17 @@ Command Examples:
 
 The `MODE` command is used to set or remove options (or *modes*) from a given target.
 
+Numeric Replies:
+
+* {% numeric RPL_UMODEIS %}
+* {% numeric RPL_CHANNELMODEIS %}
+* {% numeric ERR_NOSUCHNICK %}
+* {% numeric ERR_NOSUCHCHANNEL %}
+* {% numeric ERR_USERSDONTMATCH %}
+* {% numeric ERR_CHANOPRIVSNEEDED %}
+* {% numeric ERR_UMODEUNKNOWNFLAG %}
+* {% numeric ERR_ONLYSERVERSCANCHANGE %}
+
 #### User mode
 
 If `<target>` is a nickname that does not exist on the network, the {% numeric ERR_NOSUCHNICK %} numeric is returned. If `<target>` is a different nick than the user who sent the command, the {% numeric ERR_USERSDONTMATCH %} numeric is returned.

--- a/_includes/modern-appendix.md
+++ b/_includes/modern-appendix.md
@@ -902,6 +902,21 @@ Returned to indicate that the connection could not be registered as the [passwor
 
 Returned to indicate that the server has been configured to explicitly deny connections from this client. The text used in the last param of this message varies wildly and typically also contains the reason for the ban and/or ban details, and SHOULD be displayed as-is by IRC clients to their users.
 
+{% numericheader ERR_ONLYSERVERSCANCHANGE %}
+
+      "<client> <target> :Only servers can change that mode
+
+Server should avoid this numeric, as it conflicts with {% numeric ERR_INVALIDUSERNAME %}
+
+{% numericheader ERR_INVALIDUSERNAME %}
+
+      "<client> :Your username is not valid
+
+Returned to indicate the username provided as the first parameter to {% message USER %}
+is invalid.
+
+Note: for historical reasons, the same numeric is used for {% numeric ERR_ONLYSERVERSCANCHANGE %}
+
 {% numericheader ERR_CHANNELISFULL %}
 
       "<client> <channel> :Cannot join channel (+l)"


### PR DESCRIPTION
Sadly, both are in common use:

* ERR_INVALIDUSERNAME is used by Ergo, InspIRCd, and ircu2/Nefarious/snircd
* ERR_ONLYSERVERSCANCHANGE is used by Bahamut, Plexus4, and UnrealIRCd

I'll discuss this with server devs to try to resolve the clash.