### PR TITLE
Fix order of connection registration numerics

### DIFF
--- a/index.md
+++ b/index.md
@@ -119,7 +119,17 @@ If the server is waiting to complete a lookup of client information (such as hos
 
 Additionally, some servers also send a {% message PING %} and require a matching {% command PONG %} from the client before continuing. This exchange may happen immediately on connection and at any time during connection registration, so clients MUST respond correctly to it.
 
-Upon successful completion of the registration process, the server MUST send, in this order, the {% numeric RPL_WELCOME %}, {% numeric RPL_YOURHOST %}, {% numeric RPL_CREATED %}, {% numeric RPL_MYINFO %}, and at least one {% numeric RPL_ISUPPORT %} numeric to the client. The server SHOULD then respond as though the client sent the {% command LUSERS %} command and return the appropriate numerics. If the user has client modes set on them automatically upon joining the network, the server SHOULD send the client the {% numeric RPL_UMODEIS %} reply or a {% message MODE %} message with the client as target, preferably the former. The server MAY send other numerics and messages. The server MUST then respond as though the client sent it the {% message MOTD %} command, i.e. it must send either the successful [Message of the Day](#motd-message) numerics or the {% numeric ERR_NOMOTD %} numeric.
+Upon successful completion of the registration process, the server MUST send, in this order:
+
+1. {% numeric RPL_WELCOME %},
+2. {% numeric RPL_YOURHOST %},
+3. {% numeric RPL_CREATED %},
+4. {% numeric RPL_MYINFO %},
+5. at least one {% numeric RPL_ISUPPORT %} numeric to the client.
+6. The server MAY then send other numerics and messages.
+7. The server SHOULD then respond as though the client sent the {% command LUSERS %} command and return the appropriate numerics.
+8. The server MUST then respond as though the client sent it the {% message MOTD %} command, i.e. it must send either the successful [Message of the Day](#motd-message) numerics or the {% numeric ERR_NOMOTD %} numeric.
+9. If the user has client modes set on them automatically upon joining the network, the server SHOULD send the client the {% numeric RPL_UMODEIS %} reply or a {% message MODE %} message with the client as target, preferably the former.
 
 The first parameter of the {% numeric RPL_WELCOME %} message is the nickname assigned by the network to the client. Since it may differ from the nickname the client requested with the `NICK` command (due to, e.g. length limits or policy restrictions on nicknames), the client SHOULD use this parameter to determine its actual nickname at the time of connection. Subsequent nickname changes, client-initiated or not, will be communicated by the server sending a {% message NICK %} message.
 


### PR DESCRIPTION
In practice, the only extra numerics seem to be RPL_YOURID (irc2) and RPL_VISIBLEHOST (UnrealIRCd).

irctest: https://github.com/progval/irctest/pull/233