### PR TITLE
RPL_WHOISCHANNELS: Mention trailing space

### DIFF
--- a/_includes/modern-appendix.md
+++ b/_includes/modern-appendix.md
@@ -498,6 +498,7 @@ This numeric is sent after all other `WHOIS` response numerics have been sent to
       "<client> <nick> :[prefix]<channel>{ [prefix]<channel>}
 
 Sent as a reply to the {% message WHOIS %} command, this numeric lists the channels that the client with the nickname `<nick>` is joined to and their status in these channels. `<prefix>` is the highest [channel membership prefix](#channel-membership-prefixes) that the client has in that channel, if the client has one. `<channel>` is the name of a channel that the client is joined to. The last parameter of this numeric is a list of `[prefix]<channel>` pairs, delimited by a SPACE character `(' ', 0x20)`.
+Clients MUST ignore the trailing SPACE character, if any.
 
 `RPL_WHOISCHANNELS` can be sent multiple times in the same whois reply, if the target is on too many channels to fit in a single message.
 


### PR DESCRIPTION
RFCs 1459 and 2812 *require* this space to be present, and some servers do send it (irc2, ircu2, charybdis, unrealircd).

I am keeping it out of the grammar because it looks like an accident in implementations that somehow made it to the RFCs; and most IRCds corrected it already (Ergo, Hybrid, InspIRCd, ngIRCd, Plexus4, Solanum).

found by https://github.com/progval/irctest/pull/261