### PR TITLE
Make "parameters" syntax item a plural.

### DIFF
--- a/_includes/c2s_structure.md
+++ b/_includes/c2s_structure.md
@@ -94,7 +94,7 @@ Information on specific commands / numerics can be found in the [Client Messages
 
 This is the format of the **parameters** part:
 
-      parameter       ::=  *( SPACE middle ) [ SPACE ":" trailing ]
+      parameters      ::=  *( SPACE middle ) [ SPACE ":" trailing ]
       nospcrlfcl      ::=  <sequence of any characters except NUL, CR, LF, colon (`:`) and SPACE>
       middle          ::=  nospcrlfcl *( ":" / nospcrlfcl )
       trailing        ::=  *( ":" / " " / nospcrlfcl )


### PR DESCRIPTION
The top level `message` references to `parameters`, not `parameter`.