### PR TITLE
Fix RPL_LINKS param list, and provide an example

### DIFF
--- a/_includes/messages/optional.md
+++ b/_includes/messages/optional.md
@@ -39,6 +39,12 @@ Numeric Replies:
 * {% numeric RPL_LINKS %}
 * {% numeric RPL_ENDOFLINKS %}
 
+Reply Example:
+
+     :My.Little.Server 364 nick services.example.org My.Little.Server :1 Anope IRC Services
+     :My.Little.Server 364 nick My.Little.Server My.Little.Server :0 test server
+     :My.Little.Server 365 nick * :End of /LINKS list.
+
 ### USERHOST message
 
          Command: USERHOST

--- a/_includes/modern-appendix.md
+++ b/_includes/modern-appendix.md
@@ -677,9 +677,10 @@ Sent as a reply to the {% message NAMES %} command, this numeric lists the clien
 
 {% numericheader RPL_LINKS %}
 
-      "<client> * <server> :<hopcount> <server info>"
+      "<client> <server1> <server2> :<hopcount> <server info>"
 
-Sent as a reply to the {% message LINKS %} command, this numeric specifies one of the known servers on the network.
+Sent as a reply to the {% message LINKS %} command, this numeric specifies servers `<server1>` and `<server2>` are linked together.
+For servers which follow a spanning tree topology, `<server2>` is the closest to the client.
 
 `<server info>` is a string containing a description of that server.
 


### PR DESCRIPTION
This now conforms to what Charybdis/Hybrid/Plexus4/Solanum, InspIRCd, irc2, ngIRCd, and UnrealIRCd do.

Bahamut and ircu2/Nefarious do not support LINKS at all.